### PR TITLE
address bypassing out-of-index exception in List.take/skip,

### DIFF
--- a/src/Hedgehog/Shrink.fs
+++ b/src/Hedgehog/Shrink.fs
@@ -1,5 +1,7 @@
 ﻿namespace Hedgehog
 
+open System
+
 module SeqExtra =
     let cons (x : 'a) (xs : seq<'a>) : seq<'a> = 
         seq {
@@ -21,8 +23,9 @@ module Shrink =
     /// Produce all permutations of removing 'k' elements from a list.
     let removes (k0 : int) (xs0 : List<'a>) : seq<List<'a>> =
         let rec loop (k : int) (n : int) (xs : List<'a>) : seq<List<'a>> =
-            let hd = List.take k xs
-            let tl = List.skip k xs
+            let k' = Math.Min(k, xs.Length)
+            let hd = List.take k' xs
+            let tl = List.skip k' xs
             if k > n then
                 Seq.empty
             elif List.isEmpty tl then


### PR DESCRIPTION
The out-of-index exception is due to the List.take/skip functions
from the base class library. The current used List.take/skip functions
are from FSharpx.Collections, which don't throw if the take(or skip) number
is great than the list length.

This issue can be addressed using the min value between the take(or skip) number
and the list length.